### PR TITLE
Fix long line rendering

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -230,8 +230,7 @@
   border-radius: @component-border-radius 0;
   background: @base-accent-color;
   opacity: 0;
-  transform: scaleY(0);
-  transition: opacity .16s, transform .16s cubic-bezier(.80, 0, .90, .53);
+  transition: opacity .16s;
 
   .theme-one-light-ui & {
     left: 0;
@@ -240,8 +239,7 @@
 
 atom-pane.active .tab.active:before {
   opacity: 1;
-  transform: scaleY(1);
-  transition: opacity .16s, transform .32s cubic-bezier(0,.6,.2,1);
+  transition-duration: .32s;
 }
 
 

--- a/styles/tree-view.less
+++ b/styles/tree-view.less
@@ -72,8 +72,10 @@
   width: 2px;
   background: @base-accent-color;
   opacity: 0;
+  transition: opacity .16s;
 }
 
 .tree-view:focus::before {
   opacity: 1;
+  transition-duration: .32s;
 }


### PR DESCRIPTION
This PR is on top of https://github.com/atom/one-dark-ui/pull/112. It:
- adds the transition back for `opacity`.
- also remove the transforms on the tab markers. Maybe not needed, but then it's more consistent.
